### PR TITLE
fix_FFAppState_type

### DIFF
--- a/lib/pages/main_pages/home_page/home_page_widget.dart
+++ b/lib/pages/main_pages/home_page/home_page_widget.dart
@@ -677,7 +677,7 @@ class _HomePageWidgetState extends State<HomePageWidget>
                                                         .primaryBtnText,
                                               )
                                             ],
-                                            xLabels: FFAppState().xAxis,
+                                            xLabels: FFAppState().xAxis.map((value) => value.toString()).toList(),
                                             barWidth: 10.0,
                                             barBorderRadius:
                                                 BorderRadius.circular(10.0),


### PR DESCRIPTION
將主頁中 FFAppState().xAxis 的屬性轉型為 String，以解決原先double屬性與 xLabels 要求格式不同問題